### PR TITLE
Remove Raise instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ A microlibrary of [MTL](https://github.com/typelevel/cats-mtl) typeclasses and i
 
 * `oxidized-kernel`: `ConcurrentStateful` typeclass that relaxes the laws of `Stateful`
 * `oxidized-std`: `ConcurrentStateful` for `F` via a `Ref`
-* `oxidized`: all of the above, plus `Raise`, `Local` and `Stateful` via an `IOLocal` for `IO`
+* `oxidized`: all of the above, plus `Local` and `Stateful` via an `IOLocal` for `IO`

--- a/core/src/main/scala/oxidized/instances/io.scala
+++ b/core/src/main/scala/oxidized/instances/io.scala
@@ -16,9 +16,9 @@
 
 package oxidized.instances
 
-import cats.mtl.{Local, Raise, Stateful}
+import cats.mtl.{Local, Stateful}
 import cats.effect.IO
-import cats.{Applicative, Functor, Monad}
+import cats.{Applicative, Monad}
 import cats.effect.IOLocal
 
 object io extends IOInstances
@@ -40,12 +40,5 @@ trait IOInstances {
       override def applicative: Applicative[IO] = IO.asyncForIO
 
       override def ask[E2 >: E]: IO[E2] = ioLocal.get
-    }
-
-  implicit def catsMtlEffectRaiseForIO: Raise[IO, Throwable] =
-    new Raise[IO, Throwable] {
-      override def functor: Functor[IO] = IO.asyncForIO
-      override def raise[E2 <: Throwable, A](e: E2): IO[A] =
-        IO.raiseError(e)
     }
 }

--- a/core/src/test/scala/oxidized/instances/IOSpec.scala
+++ b/core/src/test/scala/oxidized/instances/IOSpec.scala
@@ -17,7 +17,7 @@
 package oxidized.instances
 
 import cats.effect.testkit.TestInstances
-import cats.mtl.laws.discipline.{HandleTests, LocalTests, StatefulTests}
+import cats.mtl.laws.discipline.{LocalTests, StatefulTests}
 import cats.effect.IOLocal
 import cats.effect.IO
 import org.specs2.mutable.Specification
@@ -36,6 +36,4 @@ class IOSpec extends Specification with Discipline with TestInstances {
   }
   checkAll("Stateful[IO]", StatefulTests[IO, Int].stateful)
   checkAll("Local[IO]", LocalTests[IO, Int].local[Int, Int])
-  checkAll("Handle[IO]", HandleTests[IO, Throwable].handle[Int])
-
 }


### PR DESCRIPTION
Resolves #6 

The tests were actually using the `Handle` instance for `ApplicativeError` rather than the `Raise` instance for `IO`  😅